### PR TITLE
Version 1.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prit-bot",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prit-bot",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
         "discord.js": "^14.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prit-bot",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Discord bot for P.R.I.T.",
   "scripts": {
     "build": "rimraf out && tsc",

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -12,11 +12,11 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { discordToken } from './environment'
 import { cycleActivities } from './features/activities'
-import { startAnnounceLoop } from './features/announcements'
 import { addReaction } from './features/reactions'
-import { startRemindersLoop } from './features/reminders'
 import type { ExtendedClient } from './types'
 import type { CommandData, CommandDefinition } from './util/command'
+import { announceLoop } from './features/announcements'
+import { remindersLoop } from './features/reminders'
 
 const client = new Client({
     intents: [
@@ -117,8 +117,8 @@ client.on(Events.ClientReady, () => {
 
     client.guilds.fetch().then(guilds => {
         guilds.forEach(guild => {
-            startAnnounceLoop(client, guild.id)
-            startRemindersLoop(client, guild.id)
+            announceLoop.start(guild.id)
+            remindersLoop.start(guild.id)
         })
     })
 })
@@ -126,8 +126,8 @@ client.on(Events.ClientReady, () => {
 client.on(Events.GuildCreate, guild => {
     console.log('Joined new guild')
     registerSlashCommands(guild.id)
-    startAnnounceLoop(client, guild.id)
-    startRemindersLoop(client, guild.id)
+    announceLoop.start(guild.id)
+    remindersLoop.start(guild.id)
 })
 
 client.on(Events.MessageCreate, message => {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -12,11 +12,11 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { discordToken } from './environment'
 import { cycleActivities } from './features/activities'
+import { announceLoop } from './features/announcements'
 import { addReaction } from './features/reactions'
+import { remindersLoop } from './features/reminders'
 import type { ExtendedClient } from './types'
 import type { CommandData, CommandDefinition } from './util/command'
-import { announceLoop } from './features/announcements'
-import { remindersLoop } from './features/reminders'
 
 const client = new Client({
     intents: [

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -5,8 +5,6 @@ import {
     PermissionFlagsBits,
     SlashCommandBuilder,
 } from 'discord.js'
-import { startAnnounceLoop } from '../features/announcements'
-import { startRemindersLoop } from '../features/reminders'
 import { AnnounceChannel } from '../types'
 import {
     addConfigurationCommands,
@@ -24,6 +22,8 @@ import {
     getAnnouncementChannel,
     getRole,
 } from '../util/guild'
+import { announceLoop } from '../features/announcements'
+import { remindersLoop } from '../features/reminders'
 
 const commands: ConfigurationCommandOptions<any, any>[] = [
     defineConfigurationCommand({
@@ -131,7 +131,7 @@ const commands: ConfigurationCommandOptions<any, any>[] = [
         get: async (value, context) => millisecondsToTimeString(value),
 
         onChange: (value, context) => {
-            startAnnounceLoop(context.client, context.guildId!)
+            announceLoop.reset(context.guildId!)
         },
     }),
 
@@ -153,7 +153,7 @@ const commands: ConfigurationCommandOptions<any, any>[] = [
         get: async (value, context) => millisecondsToTimeString(value),
 
         onChange: (value, context) => {
-            startRemindersLoop(context.client, context.guildId!)
+            remindersLoop.reset(context.guildId!)
         },
     }),
 ]

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -114,6 +114,35 @@ const commands: ConfigurationCommandOptions<any, any>[] = [
     }),
 
     defineConfigurationCommand({
+        type: ApplicationCommandOptionType.Role as const,
+        key: 'responsibleResponsibleRole' as const,
+        name: 'schedulerole',
+        description: 'Roll för den som sätter ansvarsveckor',
+
+        set: async (value, context) => {
+            const guild: Guild = context.guild!
+
+            if (!(await canUseRole(guild, value))) {
+                throw new Error(
+                    'Den rollen kan inte användas, saknar tillstånd'
+                )
+            }
+
+            return value.id
+        },
+        get: async (value, context) => {
+            const guild = context.guild!
+            const role = await getRole(value, guild)
+            if (!role) {
+                throw new Error(
+                    'Den sparade rollen för den som sätter ansvarsvecka finns inte längre'
+                )
+            }
+            return role.toString()
+        },
+    }),
+
+    defineConfigurationCommand({
         type: ApplicationCommandOptionType.String as const,
         key: 'announceTime' as const,
         name: 'announcetime',

--- a/src/commands/vecka.ts
+++ b/src/commands/vecka.ts
@@ -2,11 +2,7 @@ import {
     type ChatInputCommandInteraction,
     SlashCommandBuilder,
 } from 'discord.js'
-import {
-    getWeek,
-    getStudyWeek,
-    getCurrentlyResponsible,
-} from '../util/weekInfo'
+import { getWeek, getStudyWeek, getResponsibleNicks } from '../util/weekInfo'
 import { defineCommand } from '../util/guild'
 
 export default defineCommand({
@@ -19,7 +15,7 @@ export default defineCommand({
         const [week, studyWeek, responsible] = await Promise.all([
             getWeek(),
             getStudyWeek(),
-            getCurrentlyResponsible(guildId)
+            getResponsibleNicks(guildId)
                 .then(names => {
                     if (!names) return 'Ingen'
                     return names.join(', ')

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,10 +1,6 @@
-import {
-    PermissionFlagsBits,
-    Role,
-    type Guild,
-    type GuildMember,
-} from 'discord.js'
+import { Role, type Guild, type GuildMember } from 'discord.js'
 import fs from 'fs'
+import { ONE_HOUR_MS } from 'iamcal'
 import { DATA_FILE } from './environment'
 import type {
     AnnounceChannel,
@@ -16,12 +12,9 @@ import type {
     RemindersData,
 } from './types'
 import {
-    canUseRole,
     getAnnouncementChannel as getGuildAnnouncementChannel,
     getRole,
 } from './util/guild'
-import { splitTimeString } from './util/dates'
-import { ONE_HOUR_MS } from 'iamcal'
 
 function getData(): FullData {
     if (!fs.existsSync(DATA_FILE)) {
@@ -77,6 +70,14 @@ export async function getResponsibleRole(
     const configuration = getGuildConfiguration(guild.id)
     if (!configuration.responsibleRole) return undefined
     return getRole(configuration.responsibleRole, guild)
+}
+
+export async function getResponsibleResponsibleRole(
+    guild: Guild
+): Promise<Role | undefined> {
+    const configuration = getGuildConfiguration(guild.id)
+    if (!configuration.responsibleResponsibleRole) return undefined
+    return getRole(configuration.responsibleResponsibleRole, guild)
 }
 
 export function getDiscoveredReactions(guild: Guild): DiscoveredReactionsData {

--- a/src/features/reactions.ts
+++ b/src/features/reactions.ts
@@ -35,6 +35,8 @@ export function getReactions(): ReactionsConfig {
 
 export async function addReaction(message: Message) {
     if (message.author.bot) return
+    // Don't add reactions to long messages
+    if (message.content.length > 150) return
 
     const reactions = getReactions()
     const guild = message.guild!

--- a/src/features/reminders.ts
+++ b/src/features/reminders.ts
@@ -7,7 +7,7 @@ import {
 import { getNextTime, schedule } from '../util/dates'
 import { getUsers, PerGuildLoop } from '../util/guild'
 import {
-    getCurrentlyResponsible,
+    getResponsibleNicks,
     getDayOfResponsibilityWeek,
 } from '../util/weekInfo'
 import client from '../bot'
@@ -52,7 +52,7 @@ export async function getRemindersUserLineToday(guild: Guild): Promise<string> {
     const reminderData = getReminderData(guild.id)
 
     let userLine = ''
-    const responsibleNames = await getCurrentlyResponsible(guild.id)
+    const responsibleNames = await getResponsibleNicks(guild.id)
     if (!responsibleNames) {
         throw 'Det finns ingen ansvarig idag'
     }

--- a/src/features/responsibilityReminder.ts
+++ b/src/features/responsibilityReminder.ts
@@ -1,0 +1,61 @@
+import { ONE_DAY_MS } from 'iamcal'
+import { getResponsibleNicks } from '../util/weekInfo'
+import { getResponsibleResponsibleRole } from '../data'
+import client from '../bot'
+
+/**
+ * Send a reminder to set the responsibility week next week.
+ * @param guildId The guild to check
+ * @returns Whether or not the reminder was sent.
+ */
+export async function sendResponsibilityWeekReminder(
+    guildId: string
+): Promise<boolean> {
+    // Check if there is anybody responsible
+    const nextWeek = Date.now() + ONE_DAY_MS * 7
+    let responsibleNextWeek: string[] | undefined = undefined
+    try {
+        responsibleNextWeek = await getResponsibleNicks(guildId, nextWeek)
+    } catch {
+        console.warn(
+            'Did not send reminder to set responsibility week. Failed to get responsibility weeks'
+        )
+        return false
+    }
+
+    const responsibleExists =
+        responsibleNextWeek !== undefined && responsibleNextWeek.length !== 0
+    if (responsibleExists) return false
+
+    // Get who to send to
+    const guild = await client.guilds.fetch(guildId)
+    const responsibleResponsibleRole = await getResponsibleResponsibleRole(
+        guild
+    )
+    if (!responsibleResponsibleRole) {
+        console.warn(
+            'Unable to send reminders to set responsibility week, no responsible responsible role'
+        )
+        return false
+    }
+
+    // Update cache
+    await guild.members.fetch()
+    if (responsibleResponsibleRole.members.size === 0) {
+        console.warn(
+            'Unable to send reminders to set responsibility week, nobody has the role'
+        )
+        return false
+    }
+
+    responsibleResponsibleRole.members.forEach(member => {
+        console.debug(
+            `Sending reminder to assign responsibility week to ${member.id} (${member.displayName})`
+        )
+        member.send(
+            'Hej! Jag märkte att det inte finns någon som har ansvarsvecka imorgon så tänkte påminna dig :blush:'
+        )
+    })
+
+    return true
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export interface GuildData {
 export interface GuildConfiguration {
     announceChannel?: string
     responsibleRole?: string
+    responsibleResponsibleRole?: string
     responsibleCalendarUrl?: string
     /** Milliseconds after midnight that announcements should be sent */
     announceTime?: number

--- a/src/util/guild.ts
+++ b/src/util/guild.ts
@@ -1,6 +1,14 @@
-import { type APIRole, PermissionFlagsBits, type Role, type Guild, type GuildMember } from 'discord.js'
+import {
+    type APIRole,
+    PermissionFlagsBits,
+    type Role,
+    type Guild,
+    type GuildMember,
+    Client,
+} from 'discord.js'
 import type { AnnounceChannel } from '../types'
 import type { CommandDefinition } from './command'
+import { schedule } from './dates'
 
 /** Get a user in a guild from their nick */
 
@@ -24,7 +32,7 @@ export function getUsers(
     guild: Guild
 ): Promise<Array<[string, GuildMember | undefined]>> {
     return Promise.all(
-        nicks.map(async (name) => [name, await getUser(guild, name)])
+        nicks.map(async name => [name, await getUser(guild, name)])
     )
 }
 
@@ -32,9 +40,9 @@ export function defineCommand<T extends CommandDefinition>(commandData: T): T {
     return commandData
 }
 
-
 export async function getAnnouncementChannel(
-    id: string, guild: Guild
+    id: string,
+    guild: Guild
 ): Promise<AnnounceChannel | undefined> {
     const botMember = await guild.members.fetchMe()
     const botPermissions = botMember.permissions
@@ -49,11 +57,14 @@ export async function getAnnouncementChannel(
     }
 
     return channel?.isSendable()
-        ? channel as unknown as AnnounceChannel
+        ? (channel as unknown as AnnounceChannel)
         : undefined
 }
 
-export async function canUseRole(guild: Guild, role: APIRole | Role): Promise<boolean> {
+export async function canUseRole(
+    guild: Guild,
+    role: APIRole | Role
+): Promise<boolean> {
     const botMember = await guild.members.fetchMe()
     const botRole = botMember.roles.highest
     const botPermissions = botMember.permissions
@@ -66,7 +77,8 @@ export async function canUseRole(guild: Guild, role: APIRole | Role): Promise<bo
 }
 
 export async function getRole(
-    id: string, guild: Guild
+    id: string,
+    guild: Guild
 ): Promise<Role | undefined> {
     const role = await guild.roles.fetch(id)
 
@@ -74,4 +86,75 @@ export async function getRole(
     if (!canUseRole(guild, role)) return undefined
 
     return role
+}
+
+export class PerGuildLoop {
+    private _currentGeneration: Map<string, number>
+
+    getNextTime: (context: GuildLoopContext) => Date
+    action: (context: GuildLoopContext) => void
+
+    /**
+     * @param getNextTime A function which returns the next time the loop should run.
+     * @param action A function which performs some action once a day.
+     */
+    constructor(
+        getNextTime: (context: GuildLoopContext) => Date,
+        action: (context: GuildLoopContext) => void
+    ) {
+        this.getNextTime = getNextTime
+        this.action = action
+
+        this._currentGeneration = new Map()
+    }
+
+    /** Start a loop for this guild */
+    start(guildId: string) {
+        if (this._currentGeneration.has(guildId)) {
+            this.stop(guildId)
+        } else {
+            this._currentGeneration.set(guildId, 0)
+        }
+
+        const context: GuildLoopContext = {
+            guildId,
+            generation: this.getGeneration(guildId),
+        }
+
+        this.loop(context)
+    }
+
+    /** Stop the loop by increasing the generation. */
+    stop(guildId: string) {
+        if (!this._currentGeneration.has(guildId)) return
+        const newGeneration = (this.getGeneration(guildId) + 1) % 1_000_000_000
+        this._currentGeneration.set(guildId, newGeneration)
+    }
+
+    /** Restart the loop */
+    reset(guildId: string) {
+        this.stop(guildId)
+        this.start(guildId)
+    }
+
+    getGeneration(guildId: string): number {
+        return this._currentGeneration.get(guildId) ?? 0
+    }
+
+    private loop(context: GuildLoopContext): Promise<void> {
+        const nextTime = this.getNextTime(context)
+        return schedule(nextTime, () => {
+            // Kill loop if generation has increased
+            if (context.generation < this.getGeneration(context.guildId)) return
+
+            this.action(context)
+
+            this.loop(context)
+        })
+    }
+}
+
+interface GuildLoopContext {
+    generation: number
+    guildId: string
 }

--- a/src/util/weekInfo.ts
+++ b/src/util/weekInfo.ts
@@ -1,4 +1,10 @@
-import { ONE_DAY_MS, ONE_HOUR_MS, parseCalendar, type Calendar, type CalendarEvent } from 'iamcal'
+import {
+    ONE_DAY_MS,
+    ONE_HOUR_MS,
+    parseCalendar,
+    type Calendar,
+    type CalendarEvent,
+} from 'iamcal'
 import { getGuildConfiguration } from '../data'
 
 export function getCalendar(guildId: string): Promise<Calendar | undefined> {
@@ -24,17 +30,17 @@ export function getCalendar(guildId: string): Promise<Calendar | undefined> {
  * (case-insensitive).
  * @param guildId The ID of the guild which has the calendar
  * @param summaryPattern A regex pattern to match the event summary
+ * @param now The current time, can be changed to get other weeks
  * @returns The calendar event representing the responsibility week, or undefined if no matching events were found
  * @throws If the calendar was unable to be fetched
  */
-export async function getCurrentResponsibleEvent(
+export async function getResponsibleEvent(
     guildId: string,
+    now: number = Date.now(),
     summaryPattern: RegExp | undefined = /ansvar/i
 ): Promise<CalendarEvent | undefined> {
     const calendar = await getCalendar(guildId)
     if (!calendar) throw new Error('Failed to fetch the calendar')
-
-    const now = new Date().getTime()
 
     return calendar.getEvents().find(event => {
         const start = event.getStart()
@@ -68,12 +74,15 @@ export async function getCurrentResponsibleEvent(
 }
 
 /**
- * @returns The people who are currently responsible
+ * @param guildId The guild to fetch get the calendar from
+ * @param now The current time, can be changed to get other weeks
+ * @returns The nicks of the people who are currently responsible
  */
-export async function getCurrentlyResponsible(
-    guildId: string
+export async function getResponsibleNicks(
+    guildId: string,
+    now: number = Date.now()
 ): Promise<string[] | undefined> {
-    const event = await getCurrentResponsibleEvent(guildId)
+    const event = await getResponsibleEvent(guildId, now)
 
     if (!event) return undefined
 


### PR DESCRIPTION
## Changes

### Added

- New `schedulerole` option specifies who is responsible for setting responsiblity weeks.
  - A reminder will be sent to this person on Sunday if there is no upcoming responsibility week.

### Changed

- Reactions will no longer be added to messages longer than 150 characters.
- Announce and reminder loops now use a shared `PerGuildLoop` utility class.

### Fixed

- Announce and reminder loops not incrementing their generation.

